### PR TITLE
GitHub Actions の CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and Test
+        run: |
+          xcodebuild test \
+            -project PersonalMap.xcodeproj \
+            -scheme PersonalMap \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -configuration Debug \
+            | xcpretty || exit 1


### PR DESCRIPTION
## Summary
- `main` ブランチへの push / PR をトリガーに CI が動くワークフローを追加
- `xcodebuild test` でビルド＆テストを実行
- `xcpretty` でログを整形

## Test plan
- [ ] PR マージ後、Actions タブでワークフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)