### PR TITLE
actions/checkout を v4 から v5 に更新 (Node.js 24対応)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build and Test
         run: |


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` は Node.js 20 ベースで 2026年6月2日に非推奨になるため `@v5` に更新
- `@v5` は Node.js 24 ネイティブ対応

## Test plan
- [ ] CI が警告なく通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)