### PR TITLE
fix: saveMapLayerIds でレイヤーの並び順が消えるバグを修正

### DIFF
--- a/PersonalMap/Repository/FileRepository.swift
+++ b/PersonalMap/Repository/FileRepository.swift
@@ -49,11 +49,13 @@ struct FileRepository {
         let fileUrl = try getDocumentsDirectoryUrl().appendingPathComponent(layerDirectoryName, isDirectory: true).appendingPathComponent(fileName)
         try data.write(to: fileUrl, options: .atomic)
         
-        // layers.json を更新する
+        // layers.json を更新する（新規レイヤーの場合のみ追加）
         let layersFileUrl = try getLayersFileUrl()
         let mapLayersIdsData = try Data(contentsOf: layersFileUrl)
         var mapLayersIds = try JSONDecoder().decode([UUID].self, from: mapLayersIdsData)
-        mapLayersIds.append(mapLayer.id)
+        if !mapLayersIds.contains(mapLayer.id) {
+            mapLayersIds.append(mapLayer.id)
+        }
         try saveMapLayerIds(mapLayerIds: mapLayersIds)
     }
     

--- a/PersonalMap/Repository/FileRepository.swift
+++ b/PersonalMap/Repository/FileRepository.swift
@@ -249,8 +249,7 @@ struct FileRepository {
     }
     
     private func saveMapLayerIds(mapLayerIds: [UUID]) throws {
-        // 重複して保存することを防ぐために Set にする
-        let mapLayersData = try JSONEncoder().encode(Set(mapLayerIds))
+        let mapLayersData = try JSONEncoder().encode(mapLayerIds)
         let layersFileUrl = try getLayersFileUrl()
         try mapLayersData.write(to: layersFileUrl, options: .atomic)
     }


### PR DESCRIPTION
## Summary
- `saveMapLayerIds` で `Set` に変換していたため、レイヤーを並び替えても保存時に順番がリセットされていた
- `Set` への変換を削除し、配列のまま保存するよう修正

Closes #9

## Test plan
- [ ] CI が通ることを確認
- [ ] レイヤーを並び替えてアプリを再起動しても順番が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)