### PR TITLE
fix: try! を do-catch による適切なエラーハンドリングに置き換え

### DIFF
--- a/PersonalMap/Repository/FileRepository.swift
+++ b/PersonalMap/Repository/FileRepository.swift
@@ -10,7 +10,7 @@ struct FileRepository {
     let pdfDirectoryName = "pdf"
 
     init() {
-        try! initialize()
+        try? initialize()
     }
 
     func initialize() throws {
@@ -76,7 +76,7 @@ struct FileRepository {
         // MapLayerのID達を取得
         let mapLayersIds = try getMapLayerIds()
         for mapLayersId in mapLayersIds {
-            let mapLayer = try! getMapLayer(mapLayerId: mapLayersId)
+            let mapLayer = try getMapLayer(mapLayerId: mapLayersId)
             mapLayers.append(mapLayer)
         }
         return mapLayers

--- a/PersonalMap/Views/ConfigTab/Config/ConfigView.swift
+++ b/PersonalMap/Views/ConfigTab/Config/ConfigView.swift
@@ -105,6 +105,14 @@ struct ConfigView: View {
             } message: {
                 Text("データを削除し、初期設定に戻しますがよろしいですか？")
             }
+            .alert("エラー", isPresented: Binding(
+                get: { viewState.errorMessage != nil },
+                set: { if !$0 { viewState.errorMessage = nil } }
+            )) {
+                Button("閉じる", role: .cancel) { viewState.errorMessage = nil }
+            } message: {
+                if let message = viewState.errorMessage { Text(message) }
+            }
             .sheet(isPresented: $viewState.showingActivityIndicator, content: {
                 ActivityViewController(activityItems: [URL(string: SHARE_URL_STRING)!])
             })

--- a/PersonalMap/Views/ConfigTab/Config/ConfigViewState.swift
+++ b/PersonalMap/Views/ConfigTab/Config/ConfigViewState.swift
@@ -4,6 +4,7 @@ import StoreKit
 class ConfigViewState: ObservableObject {
     @Published var showingAlert: Bool = false
     @Published var showingActivityIndicator: Bool = false
+    @Published var errorMessage: String?
 
     let fileRepository = FileRepository()
     
@@ -30,7 +31,11 @@ class ConfigViewState: ObservableObject {
     }
     
     func reset() {
-        try! fileRepository.reset()
-        NotificationCenter.default.post(name: .reset, object: nil)
+        do {
+            try fileRepository.reset()
+            NotificationCenter.default.post(name: .reset, object: nil)
+        } catch {
+            errorMessage = "リセットに失敗しました"
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/AddMapLayer/AddMapLayerView.swift
+++ b/PersonalMap/Views/ListTab/AddMapLayer/AddMapLayerView.swift
@@ -29,7 +29,6 @@ struct AddMapLayerView: View {
                     Spacer()
                     Button {
                         viewState.save()
-                        dismiss()
                     } label: {
                         Text("追加")
                             .foregroundColor(Color.black)
@@ -51,6 +50,14 @@ struct AddMapLayerView: View {
                     dismiss()
                 }
             })
+            .alert("エラー", isPresented: Binding(
+                get: { viewState.errorMessage != nil },
+                set: { if !$0 { viewState.errorMessage = nil } }
+            )) {
+                Button("閉じる", role: .cancel) { viewState.errorMessage = nil }
+            } message: {
+                if let message = viewState.errorMessage { Text(message) }
+            }
             .padding(.horizontal, 16)
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("レイヤーの新規登録")

--- a/PersonalMap/Views/ListTab/AddMapLayer/AddMapLayerViewState.swift
+++ b/PersonalMap/Views/ListTab/AddMapLayer/AddMapLayerViewState.swift
@@ -4,21 +4,24 @@ class AddMapLayerViewState: ObservableObject {
     @Published var layerName: String = ""
     @Published var layerTypeIndex = 0
     @Published var dismiss: Bool = false
-    
+    @Published var errorMessage: String?
+
+    private let fileRepository = FileRepository()
+
     func save() {
-        var layerType: MapObjectType!
-        if layerTypeIndex == 0 {
-            layerType = .point
-        } else if layerTypeIndex == 1 {
-            layerType = .polyLine
-        } else {
-            layerType = .polygon
+        let layerType: MapObjectType
+        switch layerTypeIndex {
+        case 0: layerType = .point
+        case 1: layerType = .polyLine
+        default: layerType = .polygon
         }
-        
+
         let newMapLayer = MapLayer(id: UUID(), layerName: layerName, mapObjectType: layerType, objectIds: [])
-        let fileRepository = FileRepository()
-        try! fileRepository.saveMapLayer(mapLayer: newMapLayer)
-        
-        dismiss = true
+        do {
+            try fileRepository.saveMapLayer(mapLayer: newMapLayer)
+            dismiss = true
+        } catch {
+            errorMessage = "保存に失敗しました"
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/AddMapObject/Point/AddMapPointViewState.swift
+++ b/PersonalMap/Views/ListTab/AddMapObject/Point/AddMapPointViewState.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 class AddMapPointViewState: ObservableObject {
     let mapLayerId: UUID
-    
+
     @Published var labelName: String = ""
     @Published var hidden: Bool = false
     @Published var symbolName: String = "star.circle"
@@ -12,7 +12,9 @@ class AddMapPointViewState: ObservableObject {
     @Published var message: String = ""
     @Published var showingAlert: Bool = false
     @Published var dismiss: Bool = false
-    
+
+    private let fileRepository = FileRepository()
+
     init(mapLayerId: UUID) {
         self.mapLayerId = mapLayerId
     }
@@ -40,19 +42,22 @@ class AddMapPointViewState: ObservableObject {
         }
         
         let mapObject: MapObject = .point(MapPoint(id: UUID(), imageName: symbolName, isHidden: hidden, objectName: labelName, coordinate: Coordinate(latitude: latitude, longitude: longitude), items: items))
-        let fileRepository = FileRepository()
-        try! fileRepository.initialize()
-        try! fileRepository.saveMapObject(mapObject: mapObject)
-        
-        // layer に追加
-        let mapLayer = try! fileRepository.getMapLayer(mapLayerId: mapLayerId)
-        let newMapLayer = MapLayer(
-            id: mapLayer.id,
-            layerName: mapLayer.layerName,
-            mapObjectType: mapLayer.mapObjectType,
-            objectIds: [mapObject.id] + mapLayer.objectIds)
-        try! fileRepository.saveMapLayer(mapLayer: newMapLayer)
-        
-        dismiss = true
+        do {
+            try fileRepository.saveMapObject(mapObject: mapObject)
+
+            // layer に追加
+            let mapLayer = try fileRepository.getMapLayer(mapLayerId: mapLayerId)
+            let newMapLayer = MapLayer(
+                id: mapLayer.id,
+                layerName: mapLayer.layerName,
+                mapObjectType: mapLayer.mapObjectType,
+                objectIds: [mapObject.id] + mapLayer.objectIds)
+            try fileRepository.saveMapLayer(mapLayer: newMapLayer)
+
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/AddMapObject/Polygon/AddMapPolygonViewState.swift
+++ b/PersonalMap/Views/ListTab/AddMapObject/Polygon/AddMapPolygonViewState.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 class AddMapPolygonViewState: ObservableObject {
     let mapLayerId: UUID
+
     @Published var labelName: String = ""
     @Published var hidden: Bool = false
     @Published var symbolName: String = "star.circle"
@@ -10,7 +11,9 @@ class AddMapPolygonViewState: ObservableObject {
     @Published var message: String = ""
     @Published var showingAlert: Bool = false
     @Published var dismiss: Bool = false
-    
+
+    private let fileRepository = FileRepository()
+
     init(mapLayerId: UUID) {
         self.mapLayerId = mapLayerId
     }
@@ -32,19 +35,22 @@ class AddMapPolygonViewState: ObservableObject {
         // Polygon
         let polygon: MapPolygon = MapPolygon(id: UUID(), mapObjectType: .polygon, imageName: symbolName, isHidden: hidden, objectName: labelName, coordinates: coordinates, items: [])
         let mapObject: MapObject = .polygon(polygon)
-        let fileRepository = FileRepository()
-        try! fileRepository.initialize()
-        try! fileRepository.saveMapObject(mapObject: mapObject)
+        do {
+            try fileRepository.saveMapObject(mapObject: mapObject)
 
-        // layer に追加
-        let mapLayer = try! fileRepository.getMapLayer(mapLayerId: mapLayerId)
-        let newMapLayer = MapLayer(
-            id: mapLayer.id,
-            layerName: mapLayer.layerName,
-            mapObjectType: mapLayer.mapObjectType,
-            objectIds: [mapObject.id] + mapLayer.objectIds)
-        try! fileRepository.saveMapLayer(mapLayer: newMapLayer)
-        
-        dismiss = true
+            // layer に追加
+            let mapLayer = try fileRepository.getMapLayer(mapLayerId: mapLayerId)
+            let newMapLayer = MapLayer(
+                id: mapLayer.id,
+                layerName: mapLayer.layerName,
+                mapObjectType: mapLayer.mapObjectType,
+                objectIds: [mapObject.id] + mapLayer.objectIds)
+            try fileRepository.saveMapLayer(mapLayer: newMapLayer)
+
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/AddMapObject/Polyline/AddMapPolylineViewState.swift
+++ b/PersonalMap/Views/ListTab/AddMapObject/Polyline/AddMapPolylineViewState.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 class AddMapPolylineViewState: ObservableObject {
     let mapLayerId: UUID
-    
+
     @Published var labelName: String = ""
     @Published var hidden: Bool = false
     @Published var symbolName: String = "star.circle"
@@ -11,7 +11,9 @@ class AddMapPolylineViewState: ObservableObject {
     @Published var message: String = ""
     @Published var showingAlert: Bool = false
     @Published var dismiss: Bool = false
-    
+
+    private let fileRepository = FileRepository()
+
     init(mapLayerId: UUID) {
         self.mapLayerId = mapLayerId
     }
@@ -32,20 +34,22 @@ class AddMapPolylineViewState: ObservableObject {
         }
         
         let mapObject: MapObject = .polyLine(MapPolyline(id: UUID(), imageName: symbolName, isHidden: hidden, objectName: labelName, coordinates: coordinates, items: items))
-        
-        let fileRepository = FileRepository()
-        try! fileRepository.initialize()
-        try! fileRepository.saveMapObject(mapObject: mapObject)
+        do {
+            try fileRepository.saveMapObject(mapObject: mapObject)
 
-        // layer に追加
-        let mapLayer = try! fileRepository.getMapLayer(mapLayerId: mapLayerId)
-        let newMapLayer = MapLayer(
-            id: mapLayer.id,
-            layerName: mapLayer.layerName,
-            mapObjectType: mapLayer.mapObjectType,
-            objectIds: [mapObject.id] + mapLayer.objectIds)
-        try! fileRepository.saveMapLayer(mapLayer: newMapLayer)
-        
-        dismiss = true
+            // layer に追加
+            let mapLayer = try fileRepository.getMapLayer(mapLayerId: mapLayerId)
+            let newMapLayer = MapLayer(
+                id: mapLayer.id,
+                layerName: mapLayer.layerName,
+                mapObjectType: mapLayer.mapObjectType,
+                objectIds: [mapObject.id] + mapLayer.objectIds)
+            try fileRepository.saveMapLayer(mapLayer: newMapLayer)
+
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/Common/LocationsSelecter/MultiLocationSelecter.swift
+++ b/PersonalMap/Views/ListTab/Common/LocationsSelecter/MultiLocationSelecter.swift
@@ -10,6 +10,7 @@ struct MultiLocationSelecter: View {
     @State private var location: CLLocationCoordinate2D?
     @State private var locations: [CLLocationCoordinate2D] = []
     @State private var mapObjects: [MapObject] = []
+    @State private var errorMessage: String?
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -53,21 +54,32 @@ struct MultiLocationSelecter: View {
               .padding(.bottom, 60)
         }
         .onAppear {
-            var updatedMapObjects: [MapObject] = []
-
-            let fileRepository = FileRepository()
-            let mapLayers: [MapLayer] = try! fileRepository.getMapLyers()
-            for mapLayer in mapLayers {
-                for mapObjectId in mapLayer.objectIds {
-                    let mapObject: MapObject = try! fileRepository.getMapObject(mapObjectId: mapObjectId)
-                    updatedMapObjects.append(mapObject)
+            do {
+                var updatedMapObjects: [MapObject] = []
+                let fileRepository = FileRepository()
+                let mapLayers = try fileRepository.getMapLyers()
+                for mapLayer in mapLayers {
+                    for mapObjectId in mapLayer.objectIds {
+                        let mapObject = try fileRepository.getMapObject(mapObjectId: mapObjectId)
+                        updatedMapObjects.append(mapObject)
+                    }
                 }
+
+                // 差分がある場合は更新する
+                if mapObjects != updatedMapObjects {
+                    mapObjects = updatedMapObjects
+                }
+            } catch {
+                errorMessage = "データの読み込みに失敗しました"
             }
-            
-            // 差分がある場合は更新する
-            if mapObjects != updatedMapObjects {
-                mapObjects = updatedMapObjects
-            }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("閉じる", role: .cancel) { errorMessage = nil }
+        } message: {
+            if let message = errorMessage { Text(message) }
         }
     }
 }

--- a/PersonalMap/Views/ListTab/Common/LocationsSelecter/SingleLocationSelecter.swift
+++ b/PersonalMap/Views/ListTab/Common/LocationsSelecter/SingleLocationSelecter.swift
@@ -10,6 +10,7 @@ struct SingleLocationSelecter: View {
     @State private var mapObjects: [MapObject] = []
     @State private var latitude: Double?
     @State private var longitude: Double?
+    @State private var errorMessage: String?
     
     var body: some View {
         ZStack(alignment: .bottomLeading) {
@@ -54,22 +55,32 @@ struct SingleLocationSelecter: View {
             .padding(.bottom, 32)
         }
         .onAppear {
-
-            var updatedMapObjects: [MapObject] = []
-
-            let fileRepository = FileRepository()
-            let mapLayers: [MapLayer] = try! fileRepository.getMapLyers()
-            for mapLayer in mapLayers {
-                for mapObjectId in mapLayer.objectIds {
-                    let mapObject: MapObject = try! fileRepository.getMapObject(mapObjectId: mapObjectId)
-                    updatedMapObjects.append(mapObject)
+            do {
+                var updatedMapObjects: [MapObject] = []
+                let fileRepository = FileRepository()
+                let mapLayers = try fileRepository.getMapLyers()
+                for mapLayer in mapLayers {
+                    for mapObjectId in mapLayer.objectIds {
+                        let mapObject = try fileRepository.getMapObject(mapObjectId: mapObjectId)
+                        updatedMapObjects.append(mapObject)
+                    }
                 }
+
+                // 差分がある場合は更新する
+                if mapObjects != updatedMapObjects {
+                    mapObjects = updatedMapObjects
+                }
+            } catch {
+                errorMessage = "データの読み込みに失敗しました"
             }
-            
-            // 差分がある場合は更新する
-            if mapObjects != updatedMapObjects {
-                mapObjects = updatedMapObjects
-            }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("閉じる", role: .cancel) { errorMessage = nil }
+        } message: {
+            if let message = errorMessage { Text(message) }
         }
     }
 }

--- a/PersonalMap/Views/ListTab/EditMapObject/Point/EditMapPointViewState.swift
+++ b/PersonalMap/Views/ListTab/EditMapObject/Point/EditMapPointViewState.swift
@@ -24,8 +24,12 @@ class EditMapPointViewState: ObservableObject {
         }
         
         point.coordinate = Coordinate(latitude: latitude, longitude: longnitude)
-        try! fileRepository.saveMapObject(mapObject: MapObject.point(point))
-        
-        dismiss = true
+        do {
+            try fileRepository.saveMapObject(mapObject: MapObject.point(point))
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/EditMapObject/Polygon/EditMapPolygonViewState.swift
+++ b/PersonalMap/Views/ListTab/EditMapObject/Polygon/EditMapPolygonViewState.swift
@@ -13,9 +13,12 @@ class EditMapPolygonViewState: ObservableObject {
     }
         
     func savePolygon() {
-        let fileRepository = FileRepository()
-        try! fileRepository.saveMapObject(mapObject: .polygon(polygon))
-        
-        dismiss = true
+        do {
+            try fileRepository.saveMapObject(mapObject: .polygon(polygon))
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/EditMapObject/Polyline/EditMapPolylineViewState.swift
+++ b/PersonalMap/Views/ListTab/EditMapObject/Polyline/EditMapPolylineViewState.swift
@@ -25,8 +25,12 @@ class EditMapPolylineViewState: ObservableObject {
             return
         }
         
-        try! fileRepository.saveMapObject(mapObject: MapObject.polyLine(polyline))
-
-        dismiss = true
+        do {
+            try fileRepository.saveMapObject(mapObject: MapObject.polyLine(polyline))
+            dismiss = true
+        } catch {
+            message = "保存に失敗しました"
+            showingAlert = true
+        }
     }
 }

--- a/PersonalMap/Views/ListTab/MapLayerListView/MapLayerListView.swift
+++ b/PersonalMap/Views/ListTab/MapLayerListView/MapLayerListView.swift
@@ -26,6 +26,14 @@ struct MapLayerListView: View {
                 }, content: {
                     AddMapLayerView()
                 })
+            .alert("エラー", isPresented: Binding(
+                get: { viewState.errorMessage != nil },
+                set: { if !$0 { viewState.errorMessage = nil } }
+            )) {
+                Button("閉じる", role: .cancel) { viewState.errorMessage = nil }
+            } message: {
+                if let message = viewState.errorMessage { Text(message) }
+            }
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle("レイヤーリスト")
             .navigationBarItems(

--- a/PersonalMap/Views/ListTab/MapLayerListView/MapLayerListViewState.swift
+++ b/PersonalMap/Views/ListTab/MapLayerListView/MapLayerListViewState.swift
@@ -3,37 +3,41 @@ import SwiftUI
 class MapLayerListViewState: ObservableObject {
     @Published var mapLayers: [MapLayer] = []
     @Published var showingSheet = false
+    @Published var errorMessage: String?
 
     private let fileRepository = FileRepository()
 
-    
     func plusTapped() {
         showingSheet = true
     }
-    
+
     func sheetDissmiss() {
-        try! getMapLayers()
+        do { try getMapLayers() } catch { errorMessage = "データの読み込みに失敗しました" }
     }
-    
+
     func rowMove(fromOffsets: IndexSet, toOffset: Int) {
         mapLayers.move(fromOffsets: fromOffsets, toOffset: toOffset)
-        try! fileRepository.moveMapLayer(fromOffsets: fromOffsets, toOffset: toOffset)
+        do { try fileRepository.moveMapLayer(fromOffsets: fromOffsets, toOffset: toOffset) }
+        catch { errorMessage = "並び替えに失敗しました" }
     }
-    
+
     func rowRemove(offsets: IndexSet) {
         let deleteLayerIds: [UUID] = offsets.map { mapLayers[$0].id }
-        for deleteLayerId in deleteLayerIds {
-            try! fileRepository.deleteMapLayer(mapLayerId: deleteLayerId)
+        do {
+            for deleteLayerId in deleteLayerIds {
+                try fileRepository.deleteMapLayer(mapLayerId: deleteLayerId)
+            }
+            mapLayers.remove(atOffsets: offsets)
+        } catch {
+            errorMessage = "削除に失敗しました"
         }
-        mapLayers.remove(atOffsets: offsets)
     }
-    
+
     func onAppear() {
-        try! getMapLayers()
+        do { try getMapLayers() } catch { errorMessage = "データの読み込みに失敗しました" }
     }
-    
+
     private func getMapLayers() throws {
-        let mapLayers = try! fileRepository.getMapLyers()
-        self.mapLayers = mapLayers
+        mapLayers = try fileRepository.getMapLyers()
     }
 }

--- a/PersonalMap/Views/ListTab/MapObjectList/MapObjectListView.swift
+++ b/PersonalMap/Views/ListTab/MapObjectList/MapObjectListView.swift
@@ -32,6 +32,14 @@ struct MapObjectListView: View {
         .onAppear {
             viewState.onAppear()
         }
+        .alert("エラー", isPresented: Binding(
+            get: { viewState.errorMessage != nil },
+            set: { if !$0 { viewState.errorMessage = nil } }
+        )) {
+            Button("閉じる", role: .cancel) { viewState.errorMessage = nil }
+        } message: {
+            if let message = viewState.errorMessage { Text(message) }
+        }
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(
             leading:

--- a/PersonalMap/Views/ListTab/MapObjectList/MapObjectListViewState.swift
+++ b/PersonalMap/Views/ListTab/MapObjectList/MapObjectListViewState.swift
@@ -5,6 +5,7 @@ class MapObjectListViewState: ObservableObject {
     
     @Published var showingSheet = false
     @Published var mapObjects: [MapObject] = []
+    @Published var errorMessage: String?
     
     private let fileRepository = FileRepository()
     
@@ -33,13 +34,18 @@ class MapObjectListViewState: ObservableObject {
     func rowMove(fromOffsets: IndexSet, toOffset: Int) {
         mapObjects.move(fromOffsets: fromOffsets, toOffset: toOffset)
         mapLayer.objectIds = mapObjects.map { $0.id }
-        try! fileRepository.saveMapLayer(mapLayer: mapLayer)
+        do { try fileRepository.saveMapLayer(mapLayer: mapLayer) }
+        catch { errorMessage = "保存に失敗しました" }
     }
-    
+
     func rowRemove(offsets: IndexSet) {
         let deletedMapObjectIds: [UUID] = offsets.map { mapObjects[$0].id }
-        try! deleteMapObjects(deletedMapObjectIds: deletedMapObjectIds)
-        mapObjects.remove(atOffsets: offsets)
+        do {
+            try deleteMapObjects(deletedMapObjectIds: deletedMapObjectIds)
+            mapObjects.remove(atOffsets: offsets)
+        } catch {
+            errorMessage = "削除に失敗しました"
+        }
     }
     
     func sheetDissmiss() {

--- a/PersonalMap/Views/MapTab/Top/TopViewState.swift
+++ b/PersonalMap/Views/MapTab/Top/TopViewState.swift
@@ -21,24 +21,32 @@ class TopViewState: ObservableObject {
     }
     
     func onAppear() {
-        var updatedMapObjects: [MapObject] = []
-        let mapLayers: [MapLayer] = try! fileRepository.getMapLyers()
-        for mapLayer in mapLayers {
-            for mapObjectId in mapLayer.objectIds {
-                let mapObject: MapObject = try! fileRepository.getMapObject(mapObjectId: mapObjectId)
-                updatedMapObjects.append(mapObject)
+        do {
+            var updatedMapObjects: [MapObject] = []
+            let mapLayers = try fileRepository.getMapLyers()
+            for mapLayer in mapLayers {
+                for mapObjectId in mapLayer.objectIds {
+                    let mapObject = try fileRepository.getMapObject(mapObjectId: mapObjectId)
+                    updatedMapObjects.append(mapObject)
+                }
             }
-        }
-        
-        // 差分がある場合は更新する
-        if mapObjects != updatedMapObjects {
-            mapObjects = updatedMapObjects
+
+            // 差分がある場合は更新する
+            if mapObjects != updatedMapObjects {
+                mapObjects = updatedMapObjects
+            }
+        } catch {
+            messageAlertText = "データの読み込みに失敗しました"
         }
     }
-    
+
     func anotationTapped(mapObjectId: UUID) {
-        let mapObject = try! fileRepository.getMapObject(mapObjectId: mapObjectId)
-        sheet = .showMapObject(mapObject: mapObject)
+        do {
+            let mapObject = try fileRepository.getMapObject(mapObjectId: mapObjectId)
+            sheet = .showMapObject(mapObject: mapObject)
+        } catch {
+            messageAlertText = "データの読み込みに失敗しました"
+        }
     }
     
     func longPressEnded(location: CLLocationCoordinate2D) {


### PR DESCRIPTION
## Summary
- `FileRepository`: `try! initialize()` → `try? initialize()`
- `TopViewState`: `onAppear` / `anotationTapped` を `do-catch` でラップ、エラー時は既存の `messageAlertText` でアラート表示
- `MapLayerListViewState`: `errorMessage` プロパティ追加・全 `try!` を `do-catch` に置き換え
- `MapObjectListViewState`: 同上
- `EditMap*ViewState`: 保存失敗時に既存の `showingAlert` / `message` を使用
- `AddMap*ViewState`: クラスレベルの `fileRepository` に統一・不要な `initialize()` 呼び出しを削除
- `AddMapLayerViewState`: `errorMessage` 追加・暗黙アンラップ変数（`var layerType: MapObjectType!`）を除去
- `ConfigViewState`: `errorMessage` 追加・`reset()` を `do-catch` でラップ
- `MultiLocationSelecter` / `SingleLocationSelecter`: `@State var errorMessage` 追加
- 対応するViewに `.alert` を追加

Closes #10

## Test plan
- [ ] CI が通ることを確認
- [ ] レイヤー追加・削除・並び替えが正常に動作することを確認
- [ ] オブジェクト追加・削除・編集が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)